### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/app/data/user-dao.js
+++ b/app/data/user-dao.js
@@ -1,5 +1,3 @@
-const bcrypt = require("bcrypt-nodejs");
-
 /* The UserDAO must be constructed with a connected database object */
 function UserDAO(db) {
 


### PR DESCRIPTION
To fix an unused import without changing behavior, remove the unused `bcrypt` require statement.

Best single fix:
- In `app/data/user-dao.js`, delete line 1:
  - `const bcrypt = require("bcrypt-nodejs");`

This preserves current functionality exactly (password is still stored as currently coded) while resolving the CodeQL warning. No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._